### PR TITLE
Add Component's HTML Element to FAB in Svelte

### DIFF
--- a/src/svelte/components/Fab.svelte
+++ b/src/svelte/components/Fab.svelte
@@ -12,6 +12,8 @@
   export let ios = undefined;
   export let material = undefined;
 
+  export let component = 'a'; // or 'button'
+
   export let href = undefined;
   export let text = undefined;
   export let textPosition = 'after';
@@ -35,21 +37,44 @@
   );
 </script>
 
-<a
-  class={text ? c.base.withText : c.base.iconOnly}
-  {href}
-  bind:this={rippleEl.current}
-  on:click={onClick}
-  {...$$restProps}
->
-  {#if (text || $$slots.text) && textPosition === 'before'}
-    <span class={c.text}>{text}<slot name="text" /></span>
-  {/if}
-  {#if $$slots.icon}
-    <span class={c.icon}><slot name="icon" /></span>
-  {/if}
-  {#if (text || $$slots.text) && textPosition === 'after'}
-    <span class={c.text}>{text}<slot name="text" /></span>
-  {/if}
-  <slot />
-</a>
+{#if typeof component === 'string'}
+  <svelte:element
+    this={component}
+    class={text ? c.base.withText : c.base.iconOnly}
+    {href}
+    bind:this={rippleEl.current}
+    on:click={onClick}
+    {...$$restProps}
+  >
+    {#if (text || $$slots.text) && textPosition === 'before'}
+      <span class={c.text}>{text}<slot name="text" /></span>
+    {/if}
+    {#if $$slots.icon}
+      <span class={c.icon}><slot name="icon" /></span>
+    {/if}
+    {#if (text || $$slots.text) && textPosition === 'after'}
+      <span class={c.text}>{text}<slot name="text" /></span>
+    {/if}
+    <slot />
+  </svelte:element>
+{:else}
+  <svelte:component
+    this={component}
+    class={text ? c.base.withText : c.base.iconOnly}
+    {href}
+    bind:this={rippleEl.current}
+    on:click={onClick}
+    {...$$restProps}
+  >
+    {#if (text || $$slots.text) && textPosition === 'before'}
+      <span class={c.text}>{text}<slot name="text" /></span>
+    {/if}
+    {#if $$slots.icon}
+      <span class={c.icon}><slot name="icon" /></span>
+    {/if}
+    {#if (text || $$slots.text) && textPosition === 'after'}
+      <span class={c.text}>{text}<slot name="text" /></span>
+    {/if}
+    <slot />
+  </svelte:component>
+{/if}


### PR DESCRIPTION
The `component` export of the Floating Action Button Svelte Component (FAB) was missing.
I checked the `React` and `Vue` and it was there (didn't test react and vue, but it should work).