### PR TITLE
fix DialogButton click handler

### DIFF
--- a/src/types/DialogButton.d.ts
+++ b/src/types/DialogButton.d.ts
@@ -6,6 +6,10 @@ interface Props {
    */
   component?: string;
   /**
+   * DialogButton click handler
+   */
+  onClick?: (e: any) => void;
+  /**
    * Object with Tailwind CSS colors classes
    * */
   colors?: {


### PR DESCRIPTION
Add `DialogButton` click handler to fix this error:
`Object literal may only specify known properties, and '"onClick"' does not exist in type 'DialogButtonProps'.`