### PR TITLE
fix: RadioClasses material icon

### DIFF
--- a/src/shared/classes/RadioClasses.js
+++ b/src/shared/classes/RadioClasses.js
@@ -23,7 +23,7 @@ export const RadioClasses = (props, colors, classes, darkClasses) => {
     },
     icon: {
       ios: 'text-primary',
-      material: `w-3/5 h-3/5 rounded-full ${colors.bgCheckedMaterial}`,
+      material: `w-3 h-3 rounded-full ${colors.bgCheckedMaterial}`,
       notChecked: 'opacity-0',
       checked: 'opacity-100',
     },


### PR DESCRIPTION
closes #127

### before
![image](https://user-images.githubusercontent.com/17651032/223701059-89ce5db2-4e88-4d76-8cf5-ff1e97e3b361.png)


### after
![image](https://user-images.githubusercontent.com/17651032/223700972-1590babf-dbd7-4c4d-a68c-a154e9e391ab.png)
