### PR TITLE
fix TabbarLink label

### DIFF
--- a/src/svelte/components/TabbarLink.svelte
+++ b/src/svelte/components/TabbarLink.svelte
@@ -41,9 +41,12 @@
     {/if}
     {#if hasLabel}
       <span class={c.label}>
-        {label}
-        <slot name="label" />
-        <slot />
+        {#if $$slots.label}
+          <slot name="label" />
+        {:else}
+          {label}
+          <slot />
+        {/if}
       </span>
     {/if}
   </span>


### PR DESCRIPTION
If label slot is defined (`$$slots.label`) we shouldn't show label variable (`{label}`).