### PR TITLE
Fix: Missing Children prop on KonstaProvider (React)

### DIFF
--- a/src/react/konsta-react.d.ts
+++ b/src/react/konsta-react.d.ts
@@ -22,7 +22,7 @@ interface KonstaProviderProps {
    */
   touchRipple?: boolean;
 }
-declare const KonstaProvider: React.FunctionComponent<KonstaProviderProps>;
+declare const KonstaProvider: React.FunctionComponent<React.PropsWithChildren<KonstaProviderProps>>;
 
 // HELPERS
 declare const useTheme: () => 'material' | 'ios';


### PR DESCRIPTION
Change to fix #67 

This will fix the type error children prop missing on KonstaProvider