### PR TITLE
fix(react): add missing dep array to Navbar `useEffect` hook

### DIFF
--- a/src/react/components/Navbar.jsx
+++ b/src/react/components/Navbar.jsx
@@ -165,7 +165,7 @@ const Navbar = forwardRef((props, ref) => {
   useEffect(() => {
     initScroll();
     return destroyScroll;
-  });
+  }, []);
 
   const isOutline = typeof outline === 'undefined' ? theme === 'ios' : outline;
 


### PR DESCRIPTION
I was looking through the React code for the Navbar component to better understand its implementation and noticed the `useEffect` hook has no dependency array (which I assume is an accidental oversight).