### PR TITLE
fix(react): camel case `tabIndex` in some react components

### DIFF
--- a/src/react/components/ActionsButton.jsx
+++ b/src/react/components/ActionsButton.jsx
@@ -88,7 +88,7 @@ const ActionsButton = forwardRef((props, ref) => {
     <Component
       ref={rippleElRef}
       role="button"
-      tabindex="0"
+      tabIndex="0"
       className={c.base}
       {...attrs}
     >

--- a/src/react/components/BreadcrumbsCollapsed.jsx
+++ b/src/react/components/BreadcrumbsCollapsed.jsx
@@ -47,7 +47,7 @@ const BreadcrumbsCollapsed = forwardRef((props, ref) => {
     <Component
       ref={elRef}
       role="button"
-      tabindex="0"
+      tabIndex="0"
       className={c.base}
       {...attrs}
     >

--- a/src/react/components/BreadcrumbsItem.jsx
+++ b/src/react/components/BreadcrumbsItem.jsx
@@ -51,7 +51,7 @@ const BreadcrumbsItem = forwardRef((props, ref) => {
       ref={elRef}
       className={c.base}
       role="menuitem"
-      tabindex="0"
+      tabIndex="0"
       {...attrs}
     >
       {children}

--- a/src/react/components/Button.jsx
+++ b/src/react/components/Button.jsx
@@ -153,7 +153,7 @@ const Button = forwardRef((props, ref) => {
       className={classes}
       disabled={disabled}
       role="button"
-      tabindex="0"
+      tabIndex="0"
       {...attrs}
     >
       {children}

--- a/src/react/components/DialogButton.jsx
+++ b/src/react/components/DialogButton.jsx
@@ -65,7 +65,7 @@ const DialogButton = forwardRef((props, ref) => {
         className={c.base}
         disabled={disabled}
         role="button"
-        tabindex="0"
+        tabIndex="0"
         {...attrs}
       >
         {children}

--- a/src/react/components/Fab.jsx
+++ b/src/react/components/Fab.jsx
@@ -57,7 +57,7 @@ const Fab = forwardRef((props, ref) => {
       href={href}
       ref={rippleElRef}
       role="button"
-      tabindex="0"
+      tabIndex="0"
       {...attrs}
     >
       {text && textPosition === 'before' && (


### PR DESCRIPTION
### Issue
This commit addresses issue #174  where we encountered a React warning related to the use of `tabindex` in some of React components.

### Changes Made
fixed the warning by correcting the use of `tabindex` to `tabIndex` (camel case) in the affected React components. This aligns with React's naming conventions for DOM properties.
