### PR TITLE
use `sr-only` instead of `hidden` for `Radio` & `Toggle`

### DIFF
--- a/src/shared/classes/RadioClasses.js
+++ b/src/shared/classes/RadioClasses.js
@@ -33,7 +33,7 @@ export const RadioClasses = (props, colors, classes, darkClasses) => {
       material: 'h-0.5',
     },
     input: {
-      common: 'hidden',
+      common: 'sr-only',
     },
   };
 };

--- a/src/shared/classes/ToggleClasses.js
+++ b/src/shared/classes/ToggleClasses.js
@@ -55,7 +55,7 @@ export const ToggleClasses = (props, colors, classes, dark) => {
       },
     },
     input: {
-      common: 'hidden',
+      common: 'sr-only',
     },
   };
 };


### PR DESCRIPTION
To hide an element visually without hiding it from screen readers and tab key.