### PR TITLE
add 'subtitle' props to MenuListItem.d.ts.

### DIFF
--- a/src/types/MenuListItem.d.ts
+++ b/src/types/MenuListItem.d.ts
@@ -13,4 +13,8 @@ interface Props {
    * Content of the chip media area (e.g. icon)
    */
   media?: React.ReactNode;
+  /**
+   * Content of the menu list item "subtitle" area
+   */
+  subtitle?: string | number | React.ReactNode;
 }


### PR DESCRIPTION
https://github.com/konstaui/konsta/issues/194

![image](https://github.com/konstaui/konsta/assets/6682598/9630d7ca-0139-49c7-9194-a64c0c2d51fb)

This seems to happen because MenuListItemProps inherits from HTMLElement, which has a title but no subtitle.
If you add 'subtitle' to MenuListItem.d.ts like this, the warning will not occur.

![image](https://github.com/konstaui/konsta/assets/6682598/6bc1f7e9-a51e-4e29-985f-e438676cd5c2)
