### PR TITLE
Message Svelte component - don't remove text slot from build

### DIFF
--- a/src/types/Message.d.ts
+++ b/src/types/Message.d.ts
@@ -49,7 +49,7 @@ interface Props {
   /**
    * Message text
    */
-  text?: string;
+  text?: string | React.ReactNode;
   /**
    * Message name
    */


### PR DESCRIPTION
I'd like to use the text slot defined on the Message component (to add sanitized html with {@html}

Unfortunately, build-svelte-types removes the 'text' slot from the Message component's type definitions as the line doesn't contain React.ReactNode

Added this to the slot and works correctly on the component for Svelte - unsure what the ramifications are for React.