### PR TITLE
Fix Svelte a11y warnings

### DIFF
--- a/src/svelte/components/Actions.svelte
+++ b/src/svelte/components/Actions.svelte
@@ -22,7 +22,8 @@
 </script>
 
 {#if backdrop}
-  <div class={c.backdrop[state]} on:click={onBackdropClick} />
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <div class={c.backdrop[state]} role="button" tabindex="0" on:click={onBackdropClick} />
 {/if}
 <div class={c.base[state]} {...$$restProps}>
   <slot />

--- a/src/svelte/components/Actions.svelte
+++ b/src/svelte/components/Actions.svelte
@@ -23,7 +23,7 @@
 
 {#if backdrop}
   <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <div class={c.backdrop[state]} role="button" tabindex="0" on:click={onBackdropClick} />
+  <div class={c.backdrop[state]} on:click={onBackdropClick} />
 {/if}
 <div class={c.base[state]} {...$$restProps}>
   <slot />

--- a/src/svelte/components/Badge.svelte
+++ b/src/svelte/components/Badge.svelte
@@ -26,6 +26,7 @@
   );
 </script>
 
-<span class={c.base[size]} {...$$restProps} on:click={onClick}>
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<span class={c.base[size]} {...$$restProps} role="button" tabindex="0" on:click={onClick}>
   <slot />
 </span>

--- a/src/svelte/components/Badge.svelte
+++ b/src/svelte/components/Badge.svelte
@@ -27,6 +27,6 @@
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
-<span class={c.base[size]} {...$$restProps} role="button" tabindex="0" on:click={onClick}>
+<span class={c.base[size]} {...$$restProps} on:click={onClick}>
   <slot />
 </span>

--- a/src/svelte/components/Chip.svelte
+++ b/src/svelte/components/Chip.svelte
@@ -37,7 +37,7 @@
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
-<div class={c.base[style]} {...$$restProps} role="button" tabindex="0" on:click={onClick}>
+<div class={c.base[style]} {...$$restProps} on:click={onClick}>
   {#if $$slots.media}
     <div class={c.media}><slot name="media" /></div>
   {/if}

--- a/src/svelte/components/Chip.svelte
+++ b/src/svelte/components/Chip.svelte
@@ -36,12 +36,14 @@
   );
 </script>
 
-<div class={c.base[style]} {...$$restProps} on:click={onClick}>
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<div class={c.base[style]} {...$$restProps} role="button" tabindex="0" on:click={onClick}>
   {#if $$slots.media}
     <div class={c.media}><slot name="media" /></div>
   {/if}
   <slot />
   {#if deleteButton}
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
     <div class={c.deleteButton} role="button" tabindex="0" on:click={onDelete}>
       <DeleteIcon {theme} class="h-4 w-4" />
     </div>

--- a/src/svelte/components/Dialog.svelte
+++ b/src/svelte/components/Dialog.svelte
@@ -48,7 +48,7 @@
 
 {#if backdrop}
   <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <div class={c.backdrop[state]} role="button" tabindex="0" on:click={onBackdropClick} />
+  <div class={c.backdrop[state]} on:click={onBackdropClick} />
 {/if}
 
 <div class={c.base[state]} {...$$restProps}>

--- a/src/svelte/components/Dialog.svelte
+++ b/src/svelte/components/Dialog.svelte
@@ -47,7 +47,8 @@
 </script>
 
 {#if backdrop}
-  <div class={c.backdrop[state]} on:click={onBackdropClick} />
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <div class={c.backdrop[state]} role="button" tabindex="0" on:click={onBackdropClick} />
 {/if}
 
 <div class={c.base[state]} {...$$restProps}>

--- a/src/svelte/components/ListItem.svelte
+++ b/src/svelte/components/ListItem.svelte
@@ -174,9 +174,12 @@
 </script>
 
 {#if groupTitle}
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
   <svelte:element
     this={component}
     class={cls(c.groupTitle, className)}
+    role="button"
+    tabindex="0"
     on:click={onClick}
   >
     {title}
@@ -184,9 +187,12 @@
     <slot />
   </svelte:element>
 {:else}
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
   <svelte:element
     this={component}
     class={c.base}
+    role="button"
+    tabindex="0"
     {...$$restProps}
     on:click={onClick}
   >

--- a/src/svelte/components/ListItem.svelte
+++ b/src/svelte/components/ListItem.svelte
@@ -178,8 +178,6 @@
   <svelte:element
     this={component}
     class={cls(c.groupTitle, className)}
-    role="button"
-    tabindex="0"
     on:click={onClick}
   >
     {title}
@@ -191,8 +189,6 @@
   <svelte:element
     this={component}
     class={c.base}
-    role="button"
-    tabindex="0"
     {...$$restProps}
     on:click={onClick}
   >

--- a/src/svelte/components/Message.svelte
+++ b/src/svelte/components/Message.svelte
@@ -56,8 +56,6 @@
   {id}
   bind:this={rippleEl.current}
   class={classes}
-  role="button"
-  tabindex="0"
   on:click={onClick}
   {...$$restProps}
 >

--- a/src/svelte/components/Message.svelte
+++ b/src/svelte/components/Message.svelte
@@ -50,11 +50,14 @@
   );
 </script>
 
+<!-- svelte-ignore a11y-click-events-have-key-events -->
 <svelte:element
   this={component}
   {id}
   bind:this={rippleEl.current}
   class={classes}
+  role="button"
+  tabindex="0"
   on:click={onClick}
   {...$$restProps}
 >

--- a/src/svelte/components/Notification.svelte
+++ b/src/svelte/components/Notification.svelte
@@ -42,7 +42,7 @@
 
 {#if theme === 'ios'}
   <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <div class={c.base} {...$$restProps} role="button" tabindex="0" on:click={onClick}>
+  <div class={c.base} {...$$restProps} on:click={onClick}>
     <div class={c.header}>
       {#if $$slots.icon}
         <div class={c.icon}><slot name="icon" /></div>
@@ -77,7 +77,7 @@
   </div>
 {:else}
   <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <div class={c.base} {...$$restProps} role="button" tabindex="0" on:click={onClick}>
+  <div class={c.base} {...$$restProps} on:click={onClick}>
     <div class={c.header}>
       {#if $$slots.icon}
         <div class={c.icon}><slot name="icon" /></div>

--- a/src/svelte/components/Notification.svelte
+++ b/src/svelte/components/Notification.svelte
@@ -41,7 +41,8 @@
 </script>
 
 {#if theme === 'ios'}
-  <div class={c.base} {...$$restProps} on:click={onClick}>
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <div class={c.base} {...$$restProps} role="button" tabindex="0" on:click={onClick}>
     <div class={c.header}>
       {#if $$slots.icon}
         <div class={c.icon}><slot name="icon" /></div>
@@ -55,6 +56,7 @@
         </div>
       {/if}
       {#if button || $$slots.button}
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
         <div class={c.button} role="button" tabindex="0" on:click={onClose}>
           <DeleteIcon {theme} class={c.deleteIcon} />
           <slot name="button" />
@@ -74,7 +76,8 @@
     </div>
   </div>
 {:else}
-  <div class={c.base} {...$$restProps} on:click={onClick}>
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <div class={c.base} {...$$restProps} role="button" tabindex="0" on:click={onClick}>
     <div class={c.header}>
       {#if $$slots.icon}
         <div class={c.icon}><slot name="icon" /></div>
@@ -103,6 +106,7 @@
         </div>
       </div>
       {#if button || $$slots.button}
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
         <div class={c.button} role="button" tabindex="0" on:click={onClose}>
           <DeleteIcon {theme} class={c.deleteIcon} />
           <slot name="button" />

--- a/src/svelte/components/Panel.svelte
+++ b/src/svelte/components/Panel.svelte
@@ -37,7 +37,7 @@
 
 {#if backdrop}
   <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <div class={c.backdrop[state]} role="button" tabindex="0" on:click={onBackdropClick} />
+  <div class={c.backdrop[state]} on:click={onBackdropClick} />
 {/if}
 <div class={classes} {...$$restProps}>
   <slot />

--- a/src/svelte/components/Panel.svelte
+++ b/src/svelte/components/Panel.svelte
@@ -36,7 +36,8 @@
 </script>
 
 {#if backdrop}
-  <div class={c.backdrop[state]} on:click={onBackdropClick} />
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <div class={c.backdrop[state]} role="button" tabindex="0" on:click={onBackdropClick} />
 {/if}
 <div class={classes} {...$$restProps}>
   <slot />

--- a/src/svelte/components/Popover.svelte
+++ b/src/svelte/components/Popover.svelte
@@ -127,7 +127,8 @@
 </script>
 
 {#if backdrop}
-  <div class={c.backdrop[state]} on:click={onBackdropClick} />
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <div class={c.backdrop[state]} role="button" tabindex="0" on:click={onBackdropClick} />
 {/if}
 <div bind:this={el} class={classes} style={popoverStyle} {...$$restProps}>
   {#if angle}

--- a/src/svelte/components/Popover.svelte
+++ b/src/svelte/components/Popover.svelte
@@ -128,7 +128,7 @@
 
 {#if backdrop}
   <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <div class={c.backdrop[state]} role="button" tabindex="0" on:click={onBackdropClick} />
+  <div class={c.backdrop[state]} on:click={onBackdropClick} />
 {/if}
 <div bind:this={el} class={classes} style={popoverStyle} {...$$restProps}>
   {#if angle}

--- a/src/svelte/components/Popup.svelte
+++ b/src/svelte/components/Popup.svelte
@@ -31,7 +31,8 @@
 </script>
 
 {#if backdrop}
-  <div class={c.backdrop[state]} on:click={onBackdropClick} />
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <div class={c.backdrop[state]} role="button" tabindex="0" on:click={onBackdropClick} />
 {/if}
 <div class={c.base[state]} {...$$restProps}>
   <slot />

--- a/src/svelte/components/Popup.svelte
+++ b/src/svelte/components/Popup.svelte
@@ -32,7 +32,7 @@
 
 {#if backdrop}
   <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <div class={c.backdrop[state]} role="button" tabindex="0" on:click={onBackdropClick} />
+  <div class={c.backdrop[state]} on:click={onBackdropClick} />
 {/if}
 <div class={c.base[state]} {...$$restProps}>
   <slot />

--- a/src/svelte/components/Sheet.svelte
+++ b/src/svelte/components/Sheet.svelte
@@ -30,9 +30,8 @@
 </script>
 
 {#if backdrop}
-
   <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <div class={c.backdrop[state]} role="button" tabindex="0" on:click={onBackdropClick} />
+  <div class={c.backdrop[state]} on:click={onBackdropClick} />
 {/if}
 <div class={c.base[state]} {...$$restProps}>
   <slot />

--- a/src/svelte/components/Sheet.svelte
+++ b/src/svelte/components/Sheet.svelte
@@ -30,7 +30,9 @@
 </script>
 
 {#if backdrop}
-  <div class={c.backdrop[state]} on:click={onBackdropClick} />
+
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <div class={c.backdrop[state]} role="button" tabindex="0" on:click={onBackdropClick} />
 {/if}
 <div class={c.base[state]} {...$$restProps}>
   <slot />

--- a/src/svelte/components/Stepper.svelte
+++ b/src/svelte/components/Stepper.svelte
@@ -127,6 +127,7 @@
 </script>
 
 <svelte:element this={component} class={classes} {...$$restProps}>
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
   <span
     bind:this={buttonLeftEl.current}
     class={buttonLeftClasses}
@@ -154,6 +155,7 @@
     <span class={valueClasses}>{value}</span>
   {/if}
 
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
   <span
     bind:this={buttonRightEl.current}
     class={buttonRightClasses}

--- a/src/svelte/components/icons/DeleteIcon.svelte
+++ b/src/svelte/components/icons/DeleteIcon.svelte
@@ -4,12 +4,15 @@
 </script>
 
 {#if theme === 'ios'}
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="28"
     height="28"
     viewBox="0 0 28 28"
     fill="currentcolor"
+    role="button"
+    tabindex="0"
     on:click={onClick}
     {...$$restProps}
   >
@@ -18,12 +21,15 @@
     />
   </svg>
 {:else}
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
   <svg
     width="24"
     height="24"
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    role="button"
+    tabindex="0"
     on:click={onClick}
     {...$$restProps}
   >

--- a/src/svelte/components/icons/DeleteIcon.svelte
+++ b/src/svelte/components/icons/DeleteIcon.svelte
@@ -11,8 +11,6 @@
     height="28"
     viewBox="0 0 28 28"
     fill="currentcolor"
-    role="button"
-    tabindex="0"
     on:click={onClick}
     {...$$restProps}
   >
@@ -28,8 +26,6 @@
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
-    role="button"
-    tabindex="0"
     on:click={onClick}
     {...$$restProps}
   >


### PR DESCRIPTION
This PR fixes a few Svelte a11y warnings that appear when building a Svelte project that uses Konsta:

```
A11y: <svg> with click handler must have an ARIA role
A11y: <div> with click handler must have an ARIA role
A11y: <span> with click handler must have an ARIA role
A11y: <svelte:element> with click handler must have an ARIA role
A11y: visible, non-interactive elements with an on:click event must be accompanied by a keyboard event handler. Consider whether an interactive element such as <button type="button"> or <a> might be more appropriate. See https://svelte.dev/docs/accessibility-warnings#a11y-click-events-have-key-events for more details.
```

Screenshot of some of the warnings:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/828201cd-a016-482a-94a9-74a7846f13e9">

Some of these have (had) issues opened for them:
- https://github.com/konstaui/konsta/issues/92
- https://github.com/konstaui/konsta/issues/155

In the case of https://github.com/konstaui/konsta/issues/155, it was closed with https://github.com/konstaui/konsta/commit/59216a6f4daa5b438eab0a477e2853f5195dc117, but that change didn't actually fix the file that the issue referenced (`DeleteIcon.svelte`).

For "A11y: visible, non-interactive elements with an on:click event must be accompanied by a keyboard event handler," I added a comment to suppress the warning because I wasn't sure what the desired fix was. I'd be happy to revisit that with more guidance if desired.

Versions:
```
@sveltejs/vite-plugin-svelte at 3.1.1.
konsta at 3.1.3.
```

Thanks for your consideration.