### PR TITLE
Fix `vite-plugin-svelte` warning

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -32,7 +32,8 @@
     },
     "./svelte": {
       "types": "./svelte/konsta-svelte.d.ts",
-      "import": "./svelte/konsta-svelte.js"
+      "import": "./svelte/konsta-svelte.js",
+      "svelte": "./svelte/konsta-svelte.js"
     },
     "./config": "./config.js",
     "./config.js": "./config.js"


### PR DESCRIPTION
Fix https://github.com/konstaui/konsta/issues/216. I modified this file locally in my `node_modules`, which made the warning go away.