### PR TITLE
Fix Svelte Button and Link types

### DIFF
--- a/scripts/build-svelte-types.js
+++ b/scripts/build-svelte-types.js
@@ -3,6 +3,11 @@
 const fs = require('fs-extra');
 const path = require('path');
 
+const componentSvelteElementInheritance = {
+  Button: 'HTMLButtonAttributes',
+  Link: 'HTMLAnchorAttributes',
+};
+
 const componentNativeElementInheritance = {
   Actions: 'HTMLDivElement',
   ActionsButton: 'HTMLButtonElement',
@@ -18,13 +23,11 @@ const componentNativeElementInheritance = {
   BreadcrumbsCollapsed: 'HTMLDivElement',
   BreadcrumbsItem: 'HTMLDivElement',
   BreadcrumbsSeparator: 'HTMLDivElement',
-  Button: 'HTMLButtonElement',
   Card: 'HTMLDivElement',
   Checkbox: 'HTMLLabelElement',
   Chip: 'HTMLDivElement',
   Fab: 'HTMLAnchorElement',
   Icon: 'HTMLElement',
-  Link: 'HTMLAnchorElement',
   List: 'HTMLDivElement',
   ListButton: 'HTMLLIElement',
   ListGroup: 'HTMLLIElement',
@@ -125,9 +128,15 @@ const createComponentTypes = (componentName, propsContent) => {
     })
     .join('\n');
   const slotsContent = slots.map((slot) => `'${slot}': {};`).join('\n    ');
+  const svelteElementType = componentSvelteElementInheritance[componentName];
+  const nativeElementType = componentNativeElementInheritance[componentName];
   return `
 import { SvelteComponent } from 'svelte';
-import { HTMLAttributes } from 'svelte/elements';
+${
+  svelteElementType
+    ? `import type { ${svelteElementType} } from 'svelte/elements';`
+    : `import { HTMLAttributes } from 'svelte/elements';`
+}
 
 ${propsContent}
 
@@ -137,9 +146,11 @@ interface ${componentName}Events extends Record<'',{}>{}
 
 declare class ${componentName} extends SvelteComponent<
   ${componentName}Props${
-    componentNativeElementInheritance[componentName]
-      ? ` & HTMLAttributes<${componentNativeElementInheritance[componentName]}>`
-      : ''
+    svelteElementType
+      ? ` & ${svelteElementType}`
+      : nativeElementType
+        ? ` & HTMLAttributes<${nativeElementType}>`
+        : ''
   },
   ${componentName}Events,
   {


### PR DESCRIPTION
This PR fixes the generated Svelte types for `Button` and `Link`. Currently, the types don't allow for native HTML attributes. For example, VS Code complains about `href` on `Link`, and `value` on `Button`:

<img width="700" alt="image" src="https://github.com/user-attachments/assets/6da8f95f-6fef-47d9-8499-3291a4adcbee">

Similarly, `svelte-check --tsconfig ./tsconfig.json` fails:

<img width="700" alt="image" src="https://github.com/user-attachments/assets/c82f3d37-3c5c-40b2-af20-6c69672a11a3">

I fixed the `Link` and `Button` by using Svelte's typing for it. I first manually fixed the generated types until the lint errors were quieted, and then changed the type generation code to match my manual changes.

There may be other elements that require a similar fix since I didn't exhaustively search for similar cases, and instead only fixed the cases I encountered. However, it should be easy to update additional elements if need be.

- `konsta` versions 3.1.4 and 4.0.0.
- `svelte` version 4.2.18.
- `svelte-check` version 3.8.5.
- `@tsconfig/svelte` version 5.0.4.