### PR TITLE
Prevent double `onClick` attribute on Svelte `Link`

### DIFF
--- a/scripts/build-svelte-types.js
+++ b/scripts/build-svelte-types.js
@@ -58,7 +58,6 @@ const addOnClick = [
   'Button',
   'Chip',
   'Fab',
-  'Link',
   'ListItem',
   'NavbarBackLink',
   'ListButton',


### PR DESCRIPTION
The `onClick` attribute is added twice to the Svelte `Link` type. It's added once [here](https://github.com/konstaui/konsta/blob/1acc65349492343e3d062c086669950aded0fdf1/src/types/Link.d.ts#L70) and a second time [here](https://github.com/konstaui/konsta/blob/1acc65349492343e3d062c086669950aded0fdf1/scripts/build-svelte-types.js#L61). I removed the latter addition. Please let me know if I should instead remove it from `Link.d.ts`.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/89ca1a37-1735-454d-a7d0-fd8968fa3c31">