### PR TITLE
Restore Sheet modal backdrop visibility (Tailwind v4)

### DIFF
--- a/src/shared/classes/SheetClasses.js
+++ b/src/shared/classes/SheetClasses.js
@@ -14,7 +14,7 @@ export const SheetClasses = (props, colors, baseClassName) => {
     },
     backdrop: {
       common:
-        'fixed z-40 w-full h-full left-0 top-0 bg-black bg-opacity-50 duration-400',
+        'fixed z-40 w-full h-full left-0 top-0 bg-black/50 duration-400',
       opened: '',
       closed: 'opacity-0 pointer-events-none',
     },


### PR DESCRIPTION
Fixes an issue where the Sheet modal backdrop was always invisible, regardless of the `backdrop` prop.

**Cause**: Tailwind CSS v4 removed the bg-opacity-* utilities.
Reference: https://tailwindcss.com/docs/upgrade-guide#removed-deprecated-utilities

**Solution**: Replaced deprecated bg-opacity-* usage with the new color/alpha syntax (e.g., bg-black/50) to correctly render the backdrop.

