### PR TITLE
Update Snippet return type to include string

### DIFF
--- a/scripts/build-svelte-types.js
+++ b/scripts/build-svelte-types.js
@@ -118,7 +118,7 @@ const createComponentTypes = (componentName, propsContent) => {
       });
       if (shouldBeRemoved) return '';
       if (line.includes('React.ReactNode')) {
-        return `${line.split('?:')[0]}?: Snippet;`;
+        return `${line.split('?:')[0]}?: Snippet | string;`;
       }
 
       return line;


### PR DESCRIPTION
Modify the type definition for Snippet to allow a string return type in addition to the existing Snippet type.