### PR TITLE
FIX #250: Svelte ToolbarPane type missing children property

### DIFF
--- a/scripts/build-svelte-types.js
+++ b/scripts/build-svelte-types.js
@@ -55,6 +55,7 @@ const componentNativeElementInheritance = {
   Toast: 'HTMLDivElement',
   Toggle: 'HTMLLabelElement',
   Toolbar: 'HTMLDivElement',
+  ToolbarPane: 'HTMLDivElement',
 };
 
 const addOnClick = [


### PR DESCRIPTION
Fixes #250 
Adds ToolbarPane to list of base element definitions, that provides it with a children prop.

Generated type after the change:
```
import { SvelteComponent, Snippet } from 'svelte';
import { HTMLAttributes } from 'svelte/elements';

export interface Props {
  class?: string;
  /**
   * Component's HTML Element
   *
   * @default 'div'
   */
  component?: string;
  /**
   * Object with Tailwind CSS colors classes
   * */
  colors?: {
    /**
     *
     * @default 'bg-black/10 dark:bg-white/15'
     */
    tabbarHighlightBgIos?: string;
  };
}


interface ToolbarPaneProps {}
interface ToolbarPaneProps extends Props {}
interface ToolbarPaneEvents extends Record<'',{}>{}

declare class ToolbarPane extends SvelteComponent<
  ToolbarPaneProps & HTMLAttributes<HTMLDivElement>,
  ToolbarPaneEvents,
  {
    
  }
> {}

export default ToolbarPane;
```