### PR TITLE
Fix Svelte types for Dialog and DialogButton

### DIFF
--- a/scripts/build-svelte-types.js
+++ b/scripts/build-svelte-types.js
@@ -56,6 +56,8 @@ const componentNativeElementInheritance = {
   Toggle: 'HTMLLabelElement',
   Toolbar: 'HTMLDivElement',
   ToolbarPane: 'HTMLDivElement',
+  Dialog: 'HTMLDivElement',
+  DialogButton: 'HTMLButtonElement',
 };
 
 const addOnClick = [


### PR DESCRIPTION
Similar to #251
Fix missing children on Dialog and DialogButton

<details><summary>DialogButton</summary>
<p>

```
import { SvelteComponent, Snippet } from 'svelte';
import { HTMLAttributes } from 'svelte/elements';

export interface Props {
  class?: string;
  /**
   * Component's HTML Element
   *
   * @default 'button'
   */
  component?: string;
  /**
   * DialogButton click handler
   */
  onClick?: (e: any) => void;
  /**
   * Makes button bold in iOS theme and fill in Material theme, overwrites `strongIos` and `strongMaterial`
   *
   * @default false
   */
  strong?: boolean;
  /**
   * Makes button bold in iOS theme
   *
   * @default false
   */
  strongIos?: boolean;
  /**
   * Makes button fill in Material theme
   *
   * @default false
   */
  strongMaterial?: boolean;

  /**
   * Makes button disabled
   *
   * @default false
   */
  disabled?: boolean;
}


interface DialogButtonProps {}
interface DialogButtonProps extends Props {}
interface DialogButtonEvents extends Record<'',{}>{}

declare class DialogButton extends SvelteComponent<
  DialogButtonProps & HTMLAttributes<HTMLButtonElement>,
  DialogButtonEvents,
  {
    
  }
> {}

export default DialogButton;
```

</p>
</details> 

<details><summary>Dialog</summary>
<p>

```
import { SvelteComponent, Snippet } from 'svelte';
import { HTMLAttributes } from 'svelte/elements';

export interface Props {
  class?: string;
  /**
   * Component's HTML Element
   *
   * @default 'div'
   */
  component?: string;
  /**
   * Object with Tailwind CSS colors classes
   * */
  colors?: {
    /**
     * Dialog bg color in iOS theme
     *
     * @default 'bg-ios-light-glass dark:bg-ios-dark-glass'
     */
    bgIos?: string;
    /**
     * Dialog bg color in iOS theme
     *
     * @default 'bg-md-light-surface-3 dark:bg-md-dark-surface-3'
     */
    bgMaterial?: string;
    /**
     * Title text color in iOS theme
     *
     * @default ''
     */
    titleIos?: string;
    /**
     * Title text color in Material theme
     *
     * @default 'text-md-light-on-surface dark:text-md-dark-on-surface'
     */
    titleMaterial?: string;
    /**
     * Content text color in iOS theme
     *
     * @default ''
     */
    contentTextIos?: string;
    /**
     * Content text color in Material theme
     *
     * @default 'text-md-light-on-surface-variant dark:text-md-dark-on-surface-variant'
     */
    contentTextMaterial?: string;
  };

  /**
   * Tailwind CSS classes for title font size iOS theme
   *
   * @default 'text-[17px]'
   * */
  titleFontSizeIos?: string;
  /**
   * Tailwind CSS classes for title font size Material theme
   *
   * @default 'text-[24px]'
   * */
  titleFontSizeMaterial?: string;

  /**
   * Dialog title content
   */
  title?: Snippet | string;
  /**
   * Dialog main content
   */
  content?: Snippet | string;
  /**
   * Dialog buttons content
   */
  buttons?: Snippet | string;

  /**
   * Allows to open/close Popup and set its initial state
   *
   * @default false
   */
  opened?: boolean;
  /**
   * Enables Popup backdrop (dark semi transparent layer behind)
   *
   * @default true
   */
  backdrop?: boolean;
  /**
   * Click handler on backdrop element
   */
  onBackdropClick?: (e: any) => void;
}


interface DialogProps {}
interface DialogProps extends Props {}
interface DialogEvents extends Record<'',{}>{}

declare class Dialog extends SvelteComponent<
  DialogProps & HTMLAttributes<HTMLDivElement>,
  DialogEvents,
  {
    
  }
> {}

export default Dialog;
```

</p>
</details> 