### PR TITLE
Add missing attribute iosTouchHighlight

### DIFF
--- a/src/vue/shared/KonstaProvider.vue
+++ b/src/vue/shared/KonstaProvider.vue
@@ -25,6 +25,10 @@
         type: Boolean,
         default: true,
       },
+      iosTouchHighlight: {
+        type: Boolean,
+        default: true,
+      },
       autoThemeDetection: {
         type: Boolean,
         default: true,


### PR DESCRIPTION
fix #254 warning Extraneous non-props attributes : ios-touch-highlight