### PR TITLE
Add import statement for React in SearchDisableIcon

### DIFF
--- a/src/react/components/icons/SearchDisableIcon.jsx
+++ b/src/react/components/icons/SearchDisableIcon.jsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 const SearchDisableIcon = ({ ...rest }) => {
   return (
     <svg


### PR DESCRIPTION
Missing import makes the disableButton option fails on searchbar iOS with React

It closes this issue: https://github.com/konstaui/konsta/issues/262 