### PR TITLE
Avoid svelte type collisions between element and component props

### DIFF
--- a/scripts/build-svelte-types.js
+++ b/scripts/build-svelte-types.js
@@ -147,9 +147,9 @@ interface ${componentName}Events extends Record<'',{}>{}
 declare class ${componentName} extends SvelteComponent<
   ${componentName}Props${
     svelteElementType
-      ? ` & ${svelteElementType}`
+      ? ` & Omit<${svelteElementType}, keyof Props>`
       : nativeElementType
-        ? ` & HTMLAttributes<${nativeElementType}>`
+        ? ` & Omit<HTMLAttributes<${nativeElementType}>, keyof Props>`
         : ''
   },
   ${componentName}Events,


### PR DESCRIPTION

I'm aiming to fix the following class of type conflicts between svelte component props and native element props.

e.g. for the `title` prop on  `ListItem` and on `HTMLAttributes `:

```svelte
<ListItem>
	{#snippet title()}
		Some title
	{/snippet}
</ListItem>
```

currently results in the type error:

```
Type '() => any' is not assignable to type 'string | (Snippet<[]> & string) | undefined'.
  Type '() => any' is not assignable to type 'Snippet<[]> & string'.
	Type '() => any' is not assignable to type 'string'.
```

We can fix this by omitting props types that would collide:

```diff
diff --git a/scripts/build-svelte-types.js b/scripts/build-svelte-types.js
index ccab419..48d8bda 100644
--- a/scripts/build-svelte-types.js
+++ b/scripts/build-svelte-types.js
@@ -147,9 +147,9 @@ interface ${componentName}Events extends Record<'',{}>{}
 declare class ${componentName} extends SvelteComponent<
   ${componentName}Props${
	 svelteElementType
-      ? ` & ${svelteElementType}`
+      ? ` & Omit<${svelteElementType}, keyof Props>`
	   : nativeElementType
-        ? ` & HTMLAttributes<${nativeElementType}>`
+        ? ` & Omit<HTMLAttributes<${nativeElementType}>, keyof Props>`
		 : ''
   },
   ${componentName}Events,
```