### PR TITLE
fix(vue): pass subnavbar slot to NavbarClasses for correct bgBlur/bg height

### DIFF
--- a/src/vue/components/Navbar.vue
+++ b/src/vue/components/Navbar.vue
@@ -137,6 +137,7 @@
             ...props,
             left: ctx.slots.left,
             right: ctx.slots.right,
+            subnavbar: ctx.slots.subnavbar,
             centerTitle:
               typeof props.centerTitle === 'undefined'
                 ? theme.value === 'ios'


### PR DESCRIPTION
## Problem

On iOS, the Vue `Navbar` component's `bgBlur` (backdrop-filter) and `bg` (surface gradient) elements always use the shorter height that excludes the subnavbar area. This causes the frosted glass effect to not extend over the subnavbar.

## Root cause

`NavbarClasses` already supports a `subnavbar` parameter to compute the correct height — the React component passes it via `...props` (where `subnavbar` is a declared prop), and the Svelte component passes it explicitly. However, the Vue component uses **slots** instead of props for subnavbar content, and the slot presence was not forwarded to `NavbarClasses`.

The `left` and `right` slots are already forwarded correctly:
```js
left: ctx.slots.left,
right: ctx.slots.right,
```

But `subnavbar` was missing.

## Fix

Pass `subnavbar: ctx.slots.subnavbar` to `NavbarClasses`, consistent with how `left` and `right` are handled.

## Impact

- **Vue only** — React and Svelte are not affected
- **iOS only** — the `bgBlur` element (backdrop-filter) is only rendered on iOS; on Material, `bg` already uses `h-full`
- One-line change, no breaking changes
