### PR TITLE
fix(react): prevent Form Inputs page crash from null passed to cls()

### DIFF
--- a/src/react/components/ListInput.jsx
+++ b/src/react/components/ListInput.jsx
@@ -233,7 +233,6 @@ const ListInput = (props) => {
       component={component}
       media={media}
       className={c.base}
-      title={null}
       mediaClassName={c.media}
       innerClassName={c.inner[labelStyle]}
       contentClassName={c.itemContent}

--- a/src/shared/cls.js
+++ b/src/shared/cls.js
@@ -3,7 +3,7 @@ import { twMerge } from 'tailwind-merge';
 export function classes(...args) {
   const classes = [];
   args.forEach((arg) => {
-    if (typeof arg === 'object' && arg.constructor === Object) {
+    if (arg != null && typeof arg === 'object' && arg.constructor === Object) {
       Object.keys(arg).forEach((key) => {
         if (arg[key]) classes.push(key);
       });


### PR DESCRIPTION
## Summary

The React kitchen-sink **Form Inputs** page crashes on load with:

<img width="524" height="158" alt="Screenshot 2026-07-16 at 10 50 26" src="https://github.com/user-attachments/assets/e5dfc5b1-8da6-48fa-9743-41fb0c86c814" />

**Root cause:** `ListInput` passed `title={null}` to `ListItem`. That made `isMediaItem` evaluate to `null` (not `false`), which then propagated through `&&` class expressions into `cls()`. Because `typeof null === 'object'` in JavaScript, `cls()` attempted to read `null.constructor` and threw.

**Fix:**
1. Remove `title={null}` from `ListInput` — when no title is needed, omit the prop (same approach as the Svelte implementation).
2. Guard `cls()` against `null` arguments so conditional class expressions (`foo && 'class-name'`) cannot crash the utility when they short-circuit to `null`.

This is a minimal 2-line change across the call site and the shared `cls()` helper.

### Page/Component after fix:

<img width="1180" height="2324" alt="mockup-none-localhost_5174_" src="https://github.com/user-attachments/assets/cca6c1b9-85f0-49f1-b7e5-e6173214fe19" />

## Reproduction

1. Open the React kitchen-sink → **Form Inputs** page  
   https://konstaui.com/kitchen-sink/react/dist/#/form-inputs
2. The page fails to render; the error above appears in the console.

## Test plan

- [ ] Open kitchen-sink React → Form Inputs — page renders without console errors
- [ ] Verify default, outline, and floating-label input sections render correctly
- [ ] Verify validation + clear-button sections still work
- [ ] Smoke-check other pages that use `List` / `ListItem` (no regressions)